### PR TITLE
Add Python 3 support

### DIFF
--- a/imitate_bot.py
+++ b/imitate_bot.py
@@ -4,7 +4,10 @@ from time import sleep
 import signal
 import sys
 import re
-import ConfigParser
+try:
+  import ConfigParser
+except ImportError:
+  import configparser as ConfigParser
 
 import markovify
 from slacksocket import SlackSocket
@@ -50,13 +53,13 @@ class ImitateBot(object):
   def imitate(self, name):
     if self.slack._find_user_name(name):
       if self.debug_mode:
-        print "[debug] Generating chain for:", name if name else None
+        print("[debug] Generating chain for:", name if name else None)
       mk_text = self.db.get_name_messages_string(name)
       if self.debug_mode:
-        print "[debug] Got", len(mk_text if mk_text else ""), "characters of data"
+        print("[debug] Got", len(mk_text if mk_text else ""), "characters of data")
       if mk_text is None:
         return None
-      mk = markovify.NewlineText(mk_text)
+      mk = markovify.NewlineText(mk_text.decode('utf8'))
       result = None
       for _ in range(self.imitate_attempts):
         result = mk.make_sentence(tires=100, max_words=2500)
@@ -64,7 +67,7 @@ class ImitateBot(object):
           break
       return result
     if self.debug_mode:
-      print "[debug] Could not find user:", name if name else None
+      print("[debug] Could not find user:", name if name else None)
     return False
 
   def handle_message(self, event):
@@ -90,7 +93,7 @@ class ImitateBot(object):
               self.slack.send_msg("User not found!", channel_id=event.event["channel"], confirm=False)
         else:
           self.slack.send_msg("Usage: !imitate @USERNAME", channel_id=event.event["channel"], confirm=False)
-          print "[debug] Weird stuff:", event.event
+          print("[debug] Weird stuff:", event.event)
     else:
       self.db.add_message(event.event["user"], event.event["text"])
 
@@ -99,7 +102,7 @@ if __name__ == "__main__":
   config = ConfigParser.ConfigParser()
   config.read("imitate.cfg")
 
-  print "Imitate Bot Initialising..."
+  print("Imitate Bot Initialising...")
 
   debug = config.get("imitate_bot", "debug").lower() == "true" or config.get("imitate_bot", "debug") == "1"
 
@@ -115,5 +118,5 @@ if __name__ == "__main__":
   signal.signal(signal.SIGINT, _exit_signal_handler)
   signal.signal(signal.SIGTERM, _exit_signal_handler)
 
-  print "Starting Bot..."
+  print("Starting Bot...")
   bot.start()

--- a/imitate_db.py
+++ b/imitate_db.py
@@ -242,7 +242,7 @@ class ImitateDB(object):
 
   def _load_name_into_cache(self, name):
     if self.debug_mode:
-      print "[debug] Loading into cache:", name
+      print("[debug] Loading into cache:", name)
     if self.meta["names"].has_key(name):
       self._restrict_cache()
       if not self._in_cache(name):

--- a/imitate_db.py
+++ b/imitate_db.py
@@ -34,7 +34,7 @@ class Enum(set):
 
 INTEGRITY = Enum(["OKAY",
                   "MISSING_USER_FILE",
-                  "ALIAS_MISSMATCH",
+                  "ALIAS_MISMATCH",
                   "NAME_FILE_COLLISION",
                   "EXTRANEOUS_NAME_FILES"])
 
@@ -93,7 +93,7 @@ class ImitateDB(object):
   @staticmethod
   def _hash_name(name):
     hasher = hashlib.sha256()
-    hasher.update(name)
+    hasher.update(name.encode('utf8'))
     return hasher.hexdigest()
 
   def _get_true_name(self, name):
@@ -113,7 +113,7 @@ class ImitateDB(object):
     user_file = self._user_file_path(name)
     while user_file in self.access_lock:
       time.sleep(0.01)
-      print self.access_lock
+      print(self.access_lock)
     self.access_lock.append(user_file)
     with open(user_file, "w") as fp:
       json.dump(data, fp)
@@ -180,7 +180,7 @@ class ImitateDB(object):
         name_files.remove(name_file_path)
 
     if names_with_aliases:
-      return INTEGRITY.ALIAS_MISSMATCH
+      return INTEGRITY.ALIAS_MISMATCH
 
     if name_files:
       return INTEGRITY.EXTRANEOUS_NAME_FILES
@@ -205,19 +205,19 @@ class ImitateDB(object):
 
   def _restrict_cache(self):
     if self.debug_mode:
-      print "[debug] Restricting cache..."
+      print("[debug] Restricting cache...")
     max_entries = self.max_cache_entries + math.floor(self.flexable_cache_index)
     number_to_remove = len(self.db_cache) - max_entries
     if number_to_remove < 0:
       if self.flexable_cache_index > 0:
         self.flexable_cache_index -= self.flexible_cache_step
         if self.debug_mode:
-          print "[debug] Reducing flexable cache to:", self.flexable_cache_index
+          print("[debug] Reducing flexable cache to:", self.flexable_cache_index)
     elif number_to_remove > 0:
       if self.flexable_cache_index < self.cache_flexability:
         self.flexable_cache_index += self.flexible_cache_step
         if self.debug_mode:
-          print "[debug] Increasing flexable cache to:", self.flexable_cache_index
+          print("[debug] Increasing flexable cache to:", self.flexable_cache_index)
     if number_to_remove > 0:
       entries_to_remove = []
       for name, data in self.db_cache.items():
@@ -231,12 +231,12 @@ class ImitateDB(object):
       for to_remove in entries_to_remove:
         if not self.names_needed_in_cache.has_key(to_remove[0]):
           if self.debug_mode:
-            print "          Unloading name:", to_remove[0]
+            print("          Unloading name:", to_remove[0])
           self._write_user_file(to_remove[0], self.db_cache[to_remove[0]])
           del self.db_cache[to_remove[0]]
         else:
           if self.debug_mode:
-            print "          Skipping required name:", to_remove[0]
+            print("          Skipping required name:", to_remove[0])
 
   def _load_name_into_cache(self, name):
     if self.debug_mode:
@@ -252,7 +252,7 @@ class ImitateDB(object):
 
   def get_name_messages(self, name):
     if self.debug_mode:
-      print "[debug] Getting messages for name:", name
+      print("[debug] Getting messages for name:", name)
     self._need_name(name)
     if self._load_name_into_cache(name):
       result = self.db_cache[name]["messages"]
@@ -274,13 +274,13 @@ class ImitateDB(object):
     else:
       self.names_needed_in_cache[name] = 1
     if self.debug_mode:
-      print "[debug] Needing name:", name, "now at", self.names_needed_in_cache[name]
+      print("[debug] Needing name:", name, "now at", self.names_needed_in_cache[name])
 
   def _stop_needing_name(self, name):
     if self.names_needed_in_cache.has_key(name):
       self.names_needed_in_cache[name] -= 1
       if self.debug_mode:
-        print "[debug] Un-needing name:", name, "now at", self.names_needed_in_cache[name]
+        print("[debug] Un-needing name:", name, "now at", self.names_needed_in_cache[name])
       if self.names_needed_in_cache[name] == 0:
         del self.names_needed_in_cache[name]
 
@@ -295,6 +295,6 @@ class ImitateDB(object):
     self._restrict_cache()
 
 if __name__ == "__main__":
-  print "Testing..."
+  print("Testing...")
   db = ImitateDB()
   db.close()

--- a/imitate_db.py
+++ b/imitate_db.py
@@ -48,6 +48,7 @@ class ImitateDB(object):
                 flexible_cache_step=0.5,
                 debug_mode=False
               ):
+    self._alive = True
     self.data_directory = data_directory
     self.max_cache_entries = max_cache_entries if max_cache_entries > 0 else 1
     self.meta_file = os.path.join(data_directory, "meta.json")
@@ -79,7 +80,7 @@ class ImitateDB(object):
     self.close()
 
   def __del__(self):
-    if self.meta and self.data_directory:
+    if self._alive and self.meta and self.data_directory:
       self.close(write_back_cache=False)
 
   @staticmethod
@@ -147,6 +148,7 @@ class ImitateDB(object):
     return result
 
   def close(self, write_back_cache=True):
+    self._alive = False
     self.write_back(write_back_cache=write_back_cache)
 
   def write_back(self, write_back_cache=True):


### PR DESCRIPTION
Co-exists with Python 2 support, uses try for importing ConfigParser (as it is configparser in Python 3), print function instead of statement, text is decoded explicitly (and also `MISSMATCH` typo is corrected to `MISMATCH`).